### PR TITLE
Printer: Sort object fields

### DIFF
--- a/src/Printer.ts
+++ b/src/Printer.ts
@@ -181,7 +181,8 @@ export function printType(nullable: boolean, type: T.FlattenedType, withNames: b
 				const sanitizeComment = (lineStart: string, comment: string): string => {
 					return lineStart + comment.replace(/\n/g, `\n${lineStart}`).replace(/\*\//g, '* /');
 				};
-				fields.forEach((f, idx) => {
+				const sortedFields = fields.slice().sort((a, b) => a.resultFieldName.localeCompare(b.resultFieldName));
+				sortedFields.forEach((f, idx) => {
 					const fieldName = f.resultFieldName === '' ? `''` : f.resultFieldName;
 					if (f.deprecationReason != null || f.description != null) {
 						buffer.push(`${indents}  /**`);
@@ -203,7 +204,7 @@ export function printType(nullable: boolean, type: T.FlattenedType, withNames: b
 								: `${f.exportName} | null`
 							: printType(true, f.type, withNames, i + 4);
 					buffer.push(`${indents + '  '}${fieldName}: ${typeDef};`);
-					if (idx < fields.length - 1) {
+					if (idx < sortedFields.length - 1) {
 						buffer.push('');
 					}
 				});

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -423,12 +423,12 @@ fragment P on Planet {
 	const typeNames = `export type NodeType = {
   '': Person;
 
+  filmConnection: FilmType | null;
+
   /**
    * The name of this person.
    */
   name: string | null;
-
-  filmConnection: FilmType | null;
 };
 export type FilmType = {
   '': PersonFilmsConnection;


### PR DESCRIPTION
To comply with linting rule when copying the type definition elsewhere